### PR TITLE
[HOTIFIX] run yarn to update yarn.lock file discrepancy

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7936,7 +7936,7 @@ mississippi@^3.0.0:
     stream-each "^1.1.0"
     through2 "^2.0.0"
 
-mixin-deep@^1.2.0:
+mixin-deep@^1.2.0, mixin-deep@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
   dependencies:


### PR DESCRIPTION
**The following must be included in every PR. Please check all items before submitting your request.
If an item can not be satisfied, please provide a brief explanation as to why the item is not included.**

- [ ] New feature documentation added and deployed to storybook
- [ ] Minimum 1 unit test that covers the component.
- [ ] Linter run prior to creation of pull request.
- [ ] All tests run and passed prior to creation of pull request.
- [ ] Rebased from Master prior to creation of pull request.

**Provide a brief description of your update:**
after updating dependencies in a previous PR, forgot to run `yarn` to apply those updates to yarn.lock. This caused a failure with CI deployment since the yarn.lock file was out of sync with package.json. Just had to run `yarn` on the ui package to update the yarn.lock file.