### PR TITLE
[CAMP-1920] updated repo urls

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Requirements for new PRs can be found in `.github/PULL_REQUEST_TEMPLATE.md`. The
 
 1. New feature documentation added to storybook.
 1. Provided at least 1 unit test that covers any components created/updated.
-1. Linter run prior to creation of pull request.
+1. Linter run prior to creation of pull request `yarn lint`.
 1. All tests run and passed prior to creation of pull request.
 1. Rebased from Master prior to creation of pull request.
 1. Ran `yarn bump` to update semver of any updated packages.

--- a/package.json
+++ b/package.json
@@ -40,20 +40,20 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/CampGladiator/CGUI.git"
+    "url": "git+https://github.com/CampGladiator/ui.git"
   },
   "author": "",
   "license": "",
   "bugs": {
-    "url": "https://github.com/CampGladiator/CGUI/issues"
+    "url": "https://github.com/CampGladiator/ui/issues"
   },
   "prettier": {
     "singleQuote": true,
     "semi": false,
     "trailingComma": "all"
   },
-  "homepage": "https://github.com/CampGladiator/CGUI#readme",
-  "name": "CGUI",
+  "homepage": "https://github.com/CampGladiator/ui#readme",
+  "name": "ui",
   "dependencies": {
     "react": "^16.10.2",
     "react-dom": "^16.10.2"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,9 +1,9 @@
 {
 	"name": "@campgladiator/components",
-	"version": "1.0.11",
+	"version": "1.0.12",
 	"description": "A component library for CampGladiator's React apps",
 	"author": "renanpvaz <renan.piresvz@gmail.com>",
-	"homepage": "https://github.com/CampGladiator/CGUI/tree/master/packages/components#readme",
+	"homepage": "https://github.com/CampGladiator/ui/tree/master/packages/components#readme",
 	"license": "SEE LICENSE IN license.txt",
 	"main": "",
 	"directories": {
@@ -15,7 +15,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/CampGladiator/CGUI.git"
+		"url": "git+https://github.com/CampGladiator/ui.git"
 	},
 	"scripts": {
 		"build": "babel lib -d build",
@@ -23,7 +23,7 @@
 		"test": "jest"
 	},
 	"bugs": {
-		"url": "https://github.com/CampGladiator/CGUI/issues"
+		"url": "https://github.com/CampGladiator/ui/issues"
 	},
 	"jest": {
 		"setupFilesAfterEnv": [

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,18 +1,18 @@
 {
   "name": "@campgladiator/ui",
-  "version":  "2.0.0",
+  "version": "2.0.1",
   "description": "Sass implementation of CampGladiator's Design System",
   "style": "build/main.css",
   "sass": "main.sass",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/CampGladiator/CGUI.git"
+    "url": "git+https://github.com/CampGladiator/ui.git"
   },
   "keywords": [],
   "author": "renanpvaz <renan.piresvz@gmail.com>",
   "license": "SEE LICENSE IN license.txt",
   "bugs": {
-    "url": "https://github.com/CampGladiator/CGUI/issues"
+    "url": "https://github.com/CampGladiator/ui/issues"
   },
   "devDependencies": {
     "autoprefixer": "^9.6.5",
@@ -49,7 +49,7 @@
     "semi": false,
     "trailingComma": "all"
   },
-  "homepage": "https://github.com/CampGladiator/CGUI#readme",
+  "homepage": "https://github.com/CampGladiator/ui#readme",
   "dependencies": {
     "classnames": "^2.2.6",
     "storybook-react-omit": "0.0.3"


### PR DESCRIPTION
**The following must be included in every PR. Please check all items before submitting your request.
If an item can not be satisfied, please provide a brief explanation as to why the item is not included.**

- [x] New feature documentation added and deployed to storybook.
- [n|a] Minimum 1 unit test that covers the component.
- [x] Linter run prior to creation of pull request.
- [x] All tests run and passed prior to creation of pull request.
- [x] Rebased from Master prior to creation of pull request.
- [x] Ran `yarn bump` to update semver of any updated packages.

**Provide a brief description of your update:**
The URLs in the package.json files were using an outdated repo URL which might be preventing the package from allowing pulling down the packages from NPM. 

URLs have been updated and we will try to push this to see if it resolves the issue.