### PR TITLE
Camp 1980/dropdown sizing

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@campgladiator/ui",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Sass implementation of CampGladiator's Design System",
   "style": "build/main.css",
   "sass": "main.sass",

--- a/packages/ui/sass/components/buttons.scss
+++ b/packages/ui/sass/components/buttons.scss
@@ -66,10 +66,6 @@ $white-tint: rgba(255, 255, 255, 0.4);
     --base-color: #{$navy};
   }
 
-  &--light {
-    --base-color: #{$light-gray};
-  }
-
   &--gray {
     --base-color: #{$dark-gray};
     border-color: #{$medium-gray};

--- a/packages/ui/sass/components/inputs.scss
+++ b/packages/ui/sass/components/inputs.scss
@@ -1,4 +1,4 @@
-$input-border: 2px solid #ccc;
+$input-border: 2px solid $light-gray;
 
 .fieldset {
   display: flex;
@@ -23,7 +23,7 @@ $input-border: 2px solid #ccc;
     }
 
     &--inline .input {
-      flex: 1;
+      flex: auto;
     }
   }
 
@@ -71,7 +71,7 @@ $input-border: 2px solid #ccc;
 
   &::placeholder {
     font-weight: 300;
-    color: #ccc;
+    color: $light-gray;
     opacity: 1;
   }
 
@@ -93,7 +93,7 @@ $input-border: 2px solid #ccc;
 
   &--rounded {
     border: 2px solid;
-    border-color: #ccc;
+    border-color: $light-gray;
     border-radius: 999px;
     box-sizing: border-box;
     height: 41px;
@@ -104,7 +104,7 @@ $input-border: 2px solid #ccc;
     -moz-appearance: none;
     -webkit-appearance: none;
     appearance: none;
-    background: url('https://s3.amazonaws.com/cgcdn/global-ui/images/icons/arrow-down-solid.svg');
+    background-image: url('https://s3.amazonaws.com/cgcdn/global-ui/images/icons/arrow-down-solid.svg');
     background-position: 95% 50%;
     background-repeat: no-repeat;
     background-size: 16px;

--- a/packages/ui/sass/components/inputs.scss
+++ b/packages/ui/sass/components/inputs.scss
@@ -8,6 +8,10 @@ $input-border: 2px solid $light-gray;
   &--inline {
     flex-direction: row;
 
+    & .label {
+      align-self: flex-start;
+    }
+
     @include breakpoint(phone-only) {
       flex-direction: column;
     }
@@ -20,6 +24,7 @@ $input-border: 2px solid $light-gray;
   @include breakpoint(tablet-portrait) {
     &--inline .label {
       flex: 0 0 40%;
+      align-self: center;
     }
 
     &--inline .input {
@@ -108,9 +113,10 @@ $input-border: 2px solid $light-gray;
     background-position: 95% 50%;
     background-repeat: no-repeat;
     background-size: 16px;
-    background-color: white;
+    background-color: $lightest-gray;
     cursor: pointer;
     font-size: $size-xs;
+    text-transform: uppercase;
   }
 
   &[disabled] {

--- a/packages/ui/sass/components/labels.scss
+++ b/packages/ui/sass/components/labels.scss
@@ -1,6 +1,7 @@
 .label {
   display: inline-block;
   font-family: $font-primary;
+  font-weight: 400;
   font-size: 14px;
   letter-spacing: 1.53px;
   color: $medium-gray;

--- a/packages/ui/sass/components/labels.scss
+++ b/packages/ui/sass/components/labels.scss
@@ -7,7 +7,8 @@
   color: $medium-gray;
   text-align: left;
   text-transform: uppercase;
-  line-height: 41px;
+  line-height: 1.2;
+  padding: 10px 10px 10px 0;
 }
 
 .image-label {

--- a/packages/ui/sass/elements/checkboxes.scss
+++ b/packages/ui/sass/elements/checkboxes.scss
@@ -20,7 +20,7 @@
     height: 27px;
     width: 27px;
     min-width: 27px;
-    border: 2px solid #CCC;
+    border: 2px solid $light-gray;
     border-radius: 4px;
   }
 

--- a/packages/ui/sass/settings/variables.scss
+++ b/packages/ui/sass/settings/variables.scss
@@ -5,7 +5,10 @@ $navy: #263746;
 $pavement: #231f20;
 $dark-gray: #333;
 $medium-gray: #99999a;
-$light-gray: #ededed;
+$light-gray: #d4d4d4;
+$lighter-gray: #ededed;
+$lightest-gray: #f9f9f9;
+
 
 $gladiator-gradient: linear-gradient(215.85deg, #ea3855 9.33%, #c8102e 97.69%);
 

--- a/stories/2-elements/dropdowns.stories.js
+++ b/stories/2-elements/dropdowns.stories.js
@@ -1,5 +1,4 @@
 import React from 'react'
-
 import Dropdown from '../../packages/components/lib/Dropdown'
 
 const options = [
@@ -30,13 +29,17 @@ export const defaultStory = () => (
       <label className="label">label:</label>
       <Dropdown options={options} />
     </div>
+    <div className="fieldset fieldset--inline">
+      <label className="label">label:</label>
+      <Dropdown options={options} />
+    </div>
   </>
 )
 
 defaultStory.story = {
   name: 'Default',
   parameters: {
-    layout: { rows: 3, template: '300px' },
+    layout: { rows: 4, template: 'minmax(270px, 500px)', gap: '50px', justify: 'stretch' },
     info: { maxPropArrayLength: 0 },
   },
 }


### PR DESCRIPTION
**The following must be included in every PR. Please check all items before submitting your request.
If an item can not be satisfied, please provide a brief explanation as to why the item is not included.**

- [x] New feature documentation added and deployed to storybook.
- [n|a] Minimum 1 unit test that covers the component.
- [x] Linter run prior to creation of pull request.
- [x] All tests run and passed prior to creation of pull request.
- [x] Rebased from Master prior to creation of pull request.
- [x] Ran `yarn bump` to update semver of any updated packages.

**Provide a brief description of your update:**
- updates the dropdown component styling to ensure proper sizing, styling, and mobile spacing
- updates the label for the inline inputs to ensure proper alignment, spacing, and style matching with figma
- updated light gray colors to match figma (light-gray, lighter-gray, lightest-gray)
- fixed some hard-coded colors to use sass variables instead.
- updated storybook docs for dropdown element to show the inline version.